### PR TITLE
🐛 fix: 방에 입장 안 된 유저의 소켓 사용 제한

### DIFF
--- a/src/routes/waitingRoom/WaitingRoomPage.tsx
+++ b/src/routes/waitingRoom/WaitingRoomPage.tsx
@@ -67,11 +67,16 @@ const WaitingRoomPage = () => {
           if (type === MESSAGE_TYPE.USER) {
             if (data instanceof Array) {
               setUsers(data);
+              let userInRoom = false;
               for (const user of data) {
+                if (user.nickname === nickname) {
+                  userInRoom = true;
+                }
                 if (user.isOwner) {
                   setOwner(user.nickname);
                 }
               }
+              if (!userInRoom) navigate("/home");
             }
           } else if (type === MESSAGE_TYPE.CHAT) {
             setChatList((prev) => [...prev, data]);


### PR DESCRIPTION
## 📍 작업 내용 (Content)
- 방 입장 api 호출 전 링크로 입장 제한